### PR TITLE
fix for tiny bug causing a big error

### DIFF
--- a/matchdb/matchdb.py
+++ b/matchdb/matchdb.py
@@ -120,7 +120,7 @@ def add_interests(user_id: str, # unique identifier to authenticate users
     if group_id is None:
         check = db.fetch({"user_id": user_id}).items
     else:
-        check = db.fetch({"group_id": user_id, "group_id": user_id}).items
+        check = db.fetch({"user_id": user_id, "group_id": group_id}).items
     
     if bool(check):
         # get key

--- a/notebooks/00_pymatch.ipynb
+++ b/notebooks/00_pymatch.ipynb
@@ -305,7 +305,7 @@
     "    if group_id is None:\n",
     "        check = db.fetch({\"user_id\": user_id}).items\n",
     "    else:\n",
-    "        check = db.fetch({\"group_id\": user_id, \"group_id\": user_id}).items\n",
+    "        check = db.fetch({\"user_id\": user_id, \"group_id\": group_id}).items\n",
     "    \n",
     "    if bool(check):\n",
     "        # get key\n",


### PR DESCRIPTION
in `add_interests()` the line:
```python
check = db.fetch({"group_id": user_id, "group_id": user_id}).items
```

from:
```python
    # check if user exists
    # if there's group + user ID then check for the combination
    if group_id is None:
        check = db.fetch({"user_id": user_id}).items
    else:
        check = db.fetch({"group_id": user_id, "group_id": user_id}).items
```
was always empty because that query cannot exist, and so every new interest was creating a new user in the database